### PR TITLE
Add Swift Workgroups doc

### DIFF
--- a/groups/workgroups.md
+++ b/groups/workgroups.md
@@ -1,0 +1,63 @@
+# Swift Workgroups
+
+Workgroups are made of Swift community members with certain domain expertise and drive in that area. They report into a Steering Group or, if there is no respective Steering Group, the Core Team.  
+Over time, the Workgroup may form smaller groups to focus on specific technology areas.
+
+### Charter
+Workgroups must create and maintain a charter using the Workgroup Charter Template [TODO: update with charter template link once PR is up], which defines the minimum charter structure. The responsible Steering Group must approve any changes and then ultimately to the Core Team for final approval. 
+
+### Goals
+
+All Workgroups have the following goals in common:
+
+- Figure out the tasks needed to carry out the vision by defining and prioritizing efforts.
+- Welcome new contributors by building contributor pathways to their workgroup and general domain areas.
+- Communicate those pathways in the charter, or, if applicable, related repositorities’ CONTRIBUTING.md files.
+- Actively carry out development for that domain and build documentation in support.
+- Make sure corresponding projects/repositories are healthy and maintained.
+- Channel feedback, vision docs, and proposals to the respective Steering Group and/or Core Team Representative as needed.
+
+Other specific domain or functional area goals will be listed in the respective Workgroup's charter. 
+
+### Inclusion and Diversity
+Fostering an inclusive and diverse community is critical to ensure that everybody in the Swift community feels enabled and empowered to make contributions to the Swift project.
+
+We expect Workgroups to make an effort to provide an environment where all people can thrive.
+
+### Communication
+All Workgroups will have a [Swift forums](https://forums.swift.org) category to host conversations between members and the wider Swift community. GitHub repositories and other platforms will be listed in group specific charters. 
+
+### Community Participation 
+Everyone is invited to participate in contributing to each Workgroup’s initiatives. If you’d like to contribute, consider:
+
+- Discussing ideas and experiences on the Swift Forums in the workgroup category or direct message to the group
+- Opening issues to track enhancements and bugs for the projects governed by the respective workgroup
+- Submitting pull requests to address open issues or bugs
+- Participating in the Swift Mentorship Program or other programs targeting the growth of new contributors 
+
+#### Meeting
+Every Workgroup must hold regular meetings, at least once a month, and update the necessary actions to the community if needed. The meeting schedule must be documented in the Workgroup’s charter. 
+
+### Membership
+Members of the Workgroup are volunteers working towards improving the domain of the group. They serve at the discretion of an applicable Steering Group and/or the Swift Core Team and the Swift Project Lead, who has the ultimate authority over the Workgroup decisions. 
+
+By default, we would like to see Workgroups operate in an open membership model, but Steering Groups may choose alternative mechanisms where appropriate. Final membership decisions are made by the sponsoring Steering Group.
+
+##### Chair 
+The sponsoring Steering Group also selects one member of the Workgroup as the chair. The chair has no special authority over the Workgroup and is not an official spokesperson, but they are responsible for ensuring its smooth functioning by:
+
+- Organizing and leading regular meetings.
+- Making sure Workgroup members have their ideas heard and that feedback is provided.
+- Ensuring that the Workgroup communicates effectively with the community.
+- Coordinating meetings between Workgroup members and the Steering Group and/or Core Team.
+
+#### Joining 
+Interested members must be given a method by which to join the group and participate when the group is looking to expand. 
+
+The forums are the baseline contact for new members of the group. If there is another method, it must be listed on the Workgroup’s charter. 
+
+#### Leaving the Group 
+To facilitate turnover within the Workgroup, there will be an annual check-in for participation to provide an opportunity to step down from the Workgroup, and a Call for Participation for new people to join will be announced on the Swift Forums.
+
+### Code of Conduct
+The group, its members, and those participating with and around the group are subject to the [Swift Code of Conduct](https://www.swift.org/code-of-conduct/).


### PR DESCRIPTION
This document outlines the structure, goals, and expectations for Swift Workgroups, including membership, communication, and participation guidelines.