### PR TITLE
docs: fix typos across governance documentation

### DIFF
--- a/contributing/contributor-ladder.md
+++ b/contributing/contributor-ladder.md
@@ -9,7 +9,7 @@ As you climb the contributor ladder by contributing to Swift on GitHub, you gain
 A *Member* has constructively contributed to Swift multiple times. This role is held across the entire organization, becoming a *Member* allows you to trigger CI on all repositories in the swiftlang organization on GitHub.
 
 - Requirements
-  - Make multiple constructive contributions to the Swift projects. This can be in the form of PRs, engagement on the Swift Forums, filing valuable issue, triaging them, or similar.
+  - Make multiple constructive contributions to the Swift projects. This can be in the form of PRs, engagement on the Swift Forums, filing valuable issues, triaging them, or similar.
 - Privileges
   - Ability to trigger CI testing
   - Show your membership in the swiftlang organization on your GitHub profile
@@ -32,7 +32,7 @@ A *Code Merger* has made several high-quality contributions, has enough knowledg
 - Nomination
   - Like for a *Member*, please send a message to [the code-owners group](https://forums.swift.org/g/code-owners) on the Swift forums that includes your contributions, the GitHub user name that you want to use and the repositories you want to become a *Code Merger* for. At the discretion of the code owner list, you may also be granted the *Code Merger* role for repositories that you have not contributed to but that are conceptually linked to your contributions, like `swift-syntax` and `swift-driver` after having contributed to the compiler.
 - Growth
-  - As an *Code Merger*, you are trusted not just with your own work but with helping others. In reviews, you can show that you are able to take care of a code area to become a *Code Owner*.
+  - As a *Code Merger*, you are trusted not just with your own work but with helping others. In reviews, you can show that you are able to take care of a code area to become a *Code Owner*.
 
 ## Code Owner
 

--- a/contributing/forums.md
+++ b/contributing/forums.md
@@ -17,7 +17,7 @@ Engagement on the forums should follow these guidelines:
 
 - Different users may have different preferences in choice of language for discussion and are encouraged to use their language of choice.
 
-- As a matter of courtesy, responses to a post should be in the same language as the original post in order to maintain the original inclusiveness of the discussion and not inadvertantly exclude other participants already engaged on the thread (including the author of the original post).
+- As a matter of courtesy, responses to a post should be in the same language as the original post in order to maintain the original inclusiveness of the discussion and not inadvertently exclude other participants already engaged on the thread (including the author of the original post).
 
 - A response to a post has the option of providing _additional text_ in a different language if that is helpful.
 

--- a/contributing/reporting-bugs.md
+++ b/contributing/reporting-bugs.md
@@ -11,7 +11,7 @@ When opening an issue, please include the following:
   If the issue is a crash, include a stack trace. Otherwise, describe the behavior you were expecting to see, along with the behavior you actually observed.
 
 - **A reproducible test case.**
-  Double-check that your test case reproduces the issue. A relatively small sample (roughly within 50 lines of code) is best pasted directly into the description; a larger one may be uploaded as an attachment. Consider reducing the sample to the smallest amount of code possible—a smaller test case is easier to reason about and more appealing to сontributors.
+  Double-check that your test case reproduces the issue. A relatively small sample (roughly within 50 lines of code) is best pasted directly into the description; a larger one may be uploaded as an attachment. Consider reducing the sample to the smallest amount of code possible—a smaller test case is easier to reason about and more appealing to contributors.
 
 - **A description of the environment that reproduces the problem.**
   Include information about the Swift compiler's version, the deployment target (if explicitly set) and your platform.

--- a/github-policies.md
+++ b/github-policies.md
@@ -57,11 +57,11 @@ In this GitHub organization, you'll find:
   - Accept the GitHub membership and code committers policy.
   - Accept pull requests and issues (unless it's a fork, clone, or mirror with a specific purpose detailed on the README).
   - Have a documented process in place for changes to be proposed, reviewed, and approved, as part of the “evolution” of the project. For some projects, that will be “Swift Evolution” for changes that have deep implications on the language and ecosystem, and for others, it will be through less formal processes as determined by Steering Groups/Core Team.
-  - Adopt [basic contributing guidelines](swift.org/contributing) with a contribution statement in the README or a custom CONTRIBUTING.md file is present.
+  - Adopt [basic contributing guidelines](https://swift.org/contributing) with a contribution statement in the README or a custom CONTRIBUTING.md file is present.
   - Value incremental development.
   - Adopt Swift API Design Guidelines.
 
-## Use of a 'swift-*'' prefix - guidance for the repository name.
+## Use of a 'swift-*' prefix - guidance for the repository name.
 - If it's a rewrite, keep `swift*`.
 - If it has a proper brand name, remove `swift*`.
 

--- a/groups/README.md
+++ b/groups/README.md
@@ -1,8 +1,8 @@
 # Swift Groups
 
-Three types of groups play an integral role in shaping Swifts development: Workgroups, Steering Groups, and the Core Team.  
+Three types of groups play an integral role in shaping Swift's development: Workgroups, Steering Groups, and the Core Team.  
 
-Groups are formed by interested community members reaching out to an already established Steering Group on the [Swift Forums](forums.swift.org) to see if it fits into the goals of the Swift project at this time. If so, the established Steering Group will sponsor and a charter template will be used to kick off wider dicussions with the community. The charter used to document the scope, purpose, members, community participation information, and operational processes. Established Groups charter changes go through the Core Team for final approval. 
+Groups are formed by interested community members reaching out to an already established Steering Group on the [Swift Forums](forums.swift.org) to see if it fits into the goals of the Swift project at this time. If so, the established Steering Group will sponsor and a charter template will be used to kick off wider discussions with the community. The charter used to document the scope, purpose, members, community participation information, and operational processes. Established Groups charter changes go through the Core Team for final approval. 
 
 ## Workgroups
 
@@ -22,7 +22,7 @@ Workgroups are the heart of the engineering and development work of the project.
 
 ## Steering Groups 
 
-Steering Groups are responsible for the overall strategic direction for broad area such as the overall language and provide stewardship and oversight to Workgroups. 
+Steering Groups are responsible for the overall strategic direction for a broad area such as the overall language and provide stewardship and oversight to Workgroups. 
 
 Steering Groups have evolution authority over specific functional Workgroups of the project. Evolution authority is the ability to determine the means by which a functional area receives improvements. For example, code review may be sufficient for development work in a particular area, but other areas may need a more formal review process to facilitate decision making. Each Steering Group determines the appropriate development model for each of their functional areas, and their charter defines which areas the Steering Group has evolution authority over.
 


### PR DESCRIPTION
## Summary

Fix 9 issues across 5 files in the project governance documentation:

- **contributing/forums.md**: Fix `inadvertantly` → `inadvertently`
- **contributing/reporting-bugs.md**: Replace Cyrillic homoglyph `с` (U+0441) with Latin `c` in `contributors`
- **contributing/contributor-ladder.md**: Fix `issue` → `issues` (subject-verb agreement); fix `As an` → `As a` before consonant
- **github-policies.md**: Remove stray extra quote in `'swift-*''`; add missing `https://` protocol to contributing guidelines URL
- **groups/README.md**: Fix `dicussions` → `discussions`; fix `Swifts` → `Swift's` (possessive); add missing article `a broad area`

No functional changes — documentation only.